### PR TITLE
Disable CS1591 warnings for all generated files

### DIFF
--- a/src/AnyOfCodeGenerator/AnyOfCodeGenerator.cs
+++ b/src/AnyOfCodeGenerator/AnyOfCodeGenerator.cs
@@ -397,6 +397,8 @@ public class AnyOfCodeGenerator : ISourceGenerator
         sb.AppendLine("// </auto-generated>");
         sb.AppendLine("//------------------------------------------------------------------------------");
         sb.AppendLine();
+        sb.AppendLine("#pragma warning disable CS1591");
+        sb.AppendLine();
         return sb;
     }
 }


### PR DESCRIPTION
If the AnyOf generator is used in a project with [documentation generation enabled](https://learn.microsoft.com/visualstudio/ide/reference/generate-xml-documentation-comments#enable-documentation-generation), a vast number of [CS1591 compiler warnings](https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-messages/cs1591) is issued since none of the generated types contain xml code docs.

![image](https://github.com/user-attachments/assets/8e6ae294-bd34-43b8-8ae4-a92e70568414)

The C# compiler provides no capability to suppress such warnings within a sub-scope of the project, as is documented at length here: dotnet/roslyn#41171.

Hence, the only two possible solutions are to (1) emit xml docs, or (2) disable the warning for the generated files using a `#pragma warning`.

This PR does the latter.

